### PR TITLE
set default phone values to nil, so we can access keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dealersocket-client (0.1.0)
+    dealersocket-client (0.1.1)
       activesupport
       http
       nokogiri
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
+    activesupport (5.2.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -20,13 +20,13 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     coderay (1.1.2)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     hashdiff (0.3.7)
-    http (4.0.0)
+    http (4.1.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 2.0)
@@ -35,11 +35,11 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
-    i18n (1.1.1)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
     method_source (0.9.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     minitest-reporters (1.2.0)
       ansi
@@ -48,8 +48,8 @@ GEM
       ruby-progressbar
     mocha (1.7.0)
       metaclass (~> 0.0.1)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
     pry (0.12.0)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)

--- a/lib/dealersocket/client/customer.rb
+++ b/lib/dealersocket/client/customer.rb
@@ -53,7 +53,7 @@ module Dealersocket
           person = party_hash['SpecifiedPerson']
           address = person['PostalAddress'] || {}
           phone_numbers = [person['TelephoneCommunication']].flatten.compact
-          phone_number_hash = phone_numbers.each_with_object({}) do |phone_number, object|
+          phone_number_hash = phone_numbers.each_with_object(home: nil, cell: nil, work: nil) do |phone_number, object|
             key = phone_number['UseCode'].downcase.gsub('mobile', 'cell').to_sym
             object[key] = phone_number['CompleteNumber']
           end

--- a/lib/dealersocket/client/version.rb
+++ b/lib/dealersocket/client/version.rb
@@ -2,6 +2,6 @@
 
 module Dealersocket
   module Client
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/test/dealersocket/client/customer_test.rb
+++ b/test/dealersocket/client/customer_test.rb
@@ -46,6 +46,20 @@ module Dealersocket
         assert_equal [], Customer.search(customer_params)
       end
 
+      # Test checks that if the info back from Dealersocket is missing a phone number,
+      # we still set the key of that missing number
+      def test_customer_info_to_hash_returns_hash_with_all_keys
+        assert_equal Customer.customer_info_to_hash(customer_info, 1)[:home], '1111111111'
+        phones = customer_info_phones
+        _removed = phones.shift
+        customer_info_hash = customer_info
+        customer_info_hash.dig('CustomerInformationDetail', 'CustomerParty', 'SpecifiedPerson')
+                          .store('TelephoneCommunication', phones)
+        customer_hash = Customer.customer_info_to_hash(customer_info_hash, 1)
+        assert customer_hash.key?(:home)
+        assert_nil customer_hash[:home]
+      end
+
       private
 
       def customer_params
@@ -168,6 +182,10 @@ module Dealersocket
             'EntityId' => '768999'
           }
         }
+      end
+
+      def customer_info_phones
+        customer_info.dig('CustomerInformationDetail', 'CustomerParty', 'SpecifiedPerson', 'TelephoneCommunication')
       end
     end
   end


### PR DESCRIPTION
When we send this info back to dream, we're expecting on that end for phone number keys to at least be present. We make calls in dream like `crm_customer.home` and when the `home:` key doesn't get set, we are getting errors. We want all attributes (the keys) to be present.

I have confirmed that these are the only fields we need to instantiate in this way, because that hash was being built dynamically.